### PR TITLE
Remove leading space from keywords.txt identifier

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -9,13 +9,13 @@ L298N	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-initmotor KEYWORD2
-motorLeftForwardClock KEYWORD2
-motorLeftRevertClock KEYWORD2
-motorRightForwardClock KEYWORD2
-motorRightRevertClock KEYWORD2
-motorLeftstop KEYWORD2
-motorRightstop KEYWORD2
-motorLeftbreak KEYWORD2
-motorRightbreak KEYWORD2
+initmotor	KEYWORD2
+motorLeftForwardClock	KEYWORD2
+motorLeftRevertClock	KEYWORD2
+motorRightForwardClock	KEYWORD2
+motorRightRevertClock	KEYWORD2
+motorLeftstop	KEYWORD2
+motorRightstop	KEYWORD2
+motorLeftbreak	KEYWORD2
+motorRightbreak	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords